### PR TITLE
Change_Show_Editpage

### DIFF
--- a/app/assets/stylesheets/shows.scss
+++ b/app/assets/stylesheets/shows.scss
@@ -14,18 +14,23 @@
   cursor: pointer;
 }
 
+.Wrapper {
+  text-align: -webkit-center;
+}
 
 .ShowArticle {
   padding: 50px;
-  &__page {
-    @include page_body;
-  }
   &__detail {
-    margin-top: 30px;
+    @include page_body;
+    width: 1000px;
+    text-align: left;
     &__title {
-      font-size: 20px;
+      font-size: 32px;
+      font-weight: bold;
+      width: 1000px;
     }
     &__description {
+      width: 1000px;
       font-size: 18px;
       margin: 30px 0px;
     }
@@ -35,15 +40,20 @@
   }
   &__ShowReturn {
     &__Contents {
-      width: 10vw;
+      width: 1000px;
       display: flex;
-      justify-content: space-around;
       margin-bottom: 30px;
       &__edit {
         @include SubItems;
+        margin-right: 15px;
+        width: 3vw;
+        display: block
       }
       &__delete {
         @include SubItems;
+        margin-right: 15px;
+        width: 3vw;
+        display: block
       }
       &__return {
         @include SubItems;
@@ -54,7 +64,12 @@
   }
 }
 
+.Comments {
+  text-align: center;
+}
+
 .Messages {
   padding: 50px;
-  width: 100%;
+  width: 1000px;
+  text-align: left;
 }

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -1,38 +1,40 @@
 %header
 = render('templates/header')
-.ShowArticle
-  .ShowArticle__page
-    記事の詳細
-  .ShowArticle__detail
-    .ShowArticle__detail__title
-      タイトル: #{@article.title}
-    .ShowArticle__detail__description
-      本文: #{@article.description}
-    .ShowArticle__detail__image
-      = image_tag(@article.image_url) if @article.image.present?
-  .ShowArticle__ShowReturn
-  - if user_signed_in? && current_user.id == @article.user_id
-    .ShowArticle__ShowReturn__Contents
-      .ShowArticle__ShowReturn__Contents__edit
-        = link_to '編集', edit_article_path(@article.id), method: :get
-      .ShowArticle__ShowReturn__Contents__delete
-        = link_to '削除', article_path(@article.id), method: :delete, data: {confirm: "本当に削除しますか?"}
-      .ShowArticle__ShowReturn__Contents__return
-        = link_to '戻る', articles_path
+.Wrapper
+  .ShowArticle
+    .ShowArticle__detail
+      .ShowArticle__detail__title
+        #{@article.title}
+      .ShowArticle__detail__description
+        #{@article.description}
+      .ShowArticle__detail__image
+        = image_tag(@article.image_url) if @article.image.present?
+    .ShowArticle__ShowReturn
+    - if user_signed_in? && current_user.id == @article.user_id
+      .ShowArticle__ShowReturn__Contents
+        .ShowArticle__ShowReturn__Contents__edit
+          = link_to '編集', edit_article_path(@article.id), method: :get
+        .ShowArticle__ShowReturn__Contents__delete
+          = link_to '削除', article_path(@article.id), method: :delete, data: {confirm: "本当に削除しますか?"}
+        .ShowArticle__ShowReturn__Contents__return
+          = link_to '戻る', articles_path
 
-- if current_user
-  .Comments
-    = form_with(model: [@article, @comment], local: true) do |f|
-      .Comments__text
-      %br
-        =f.text_area :text, placeholder: "コメントする", row: "2"
-      %br
-        =f.submit "投稿する"
-- else
-  ※※※ コメントの投稿には新規登録/ログインが必要です ※※※
-.Messages
-  コメント一覧
-  - if @comments
-    = @comments.each do |comment|
-      = link_to comment.user.name, user_path(comment.user.id)
-      = comment.description
+  - if current_user
+    .Comments
+      = form_with(model: [@article, @comment], local: true) do |f|
+        .Comments__text
+        %br
+          =f.text_area :description, placeholder: "コメントする", row: "2"
+        %br
+          =f.submit "投稿する"
+  - else
+    ※※※ コメントの投稿には新規登録/ログインが必要です ※※※
+  .Messages
+    %h4 ＜コメント一覧＞
+    - if @comments
+      - @comments.each do |comment|
+        %p
+          %strong
+            = link_to comment.user.name, "/users/#{comment.user_id}"
+            ：
+          = comment.description


### PR DESCRIPTION
## Why
記事詳細と編集ページのビューを整える。

## What
記事のコメント欄が上手く作動していなかった為、修正。
詳細ページは、ページを中央寄りにしている。
編集ページは、新規投稿のデザインと合わせてシンプルに。
一旦は、簡易的に見易く変更。デザインの仕上げは、後ほど。

記事ページの課題は、写真の複数枚投稿。他のプルリクエストで更新予定。